### PR TITLE
lib/plugin.py: warn if MFA identity is not digits only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 2.2.2 2020-05-13
 
 Fix traceback upon Starling token request failing. With better logging as well.
+Warn if the MFA identity is not digits only, which is the expected format for Starling IDs.
 
 2.2.1 2019-10-28
 

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -64,6 +64,7 @@ class Plugin(AAPlugin):
         return iter(steps)
 
     def do_authenticate(self):
+        self.warn_if_not_starling_id(self.mfa_identity)
         verdict = self._client.execute_authenticate(self.username, self.mfa_identity, self.mfa_password)
         if verdict.get("verdict") == "DENY" and self._client.user_doesnt_exist:
             ttl = self.plugin_configuration.getint("memory_cache", "ttl", default=3600)
@@ -137,3 +138,11 @@ class Plugin(AAPlugin):
     @staticmethod
     def _first_or_none(input_list):
         return next(iter(input_list or []), None)
+
+    def warn_if_not_starling_id(self, mfa_identity):
+        if not mfa_identity.isdigit():
+            self.logger.warning(
+                "The MFA identity ({}) does not look like a Starling ID which contains only digits!".format(
+                    mfa_identity
+                )
+            )

--- a/lib/tests/test_plugin.py
+++ b/lib/tests/test_plugin.py
@@ -31,17 +31,17 @@ CONFIG = dedent(
 """
 )
 
-USED_ID = "user_id"
+USER_ID = "user_id"
 USER_ID_CACHE_KEY = "user_id_+3601234_abc@def.com"
 
 
 @fixture
 def mocked_client():
-    def get_mocked_client(user_doesnt_exist):
+    def get_mocked_client(user_id):
         client = MagicMock()
         client.execute_authenticate.return_value = dict(verdict="DENY")
-        client.user_doesnt_exist = user_doesnt_exist
-        client.provision_user = lambda x, y, z: USED_ID
+        client.user_doesnt_exist = user_id is None
+        client.provision_user = lambda x, y, z: user_id
         return client
 
     return get_mocked_client
@@ -49,9 +49,9 @@ def mocked_client():
 
 @fixture
 def mocked_plugin(mocked_client):
-    def get_mocked_plugin(user_doesnt_exist):
+    def get_mocked_plugin(user_id):
         plugin = Plugin(CONFIG)
-        plugin.construct_mfa_client = lambda: mocked_client(user_doesnt_exist)
+        plugin.construct_mfa_client = lambda: mocked_client(user_id)
         plugin._query_user_ldap_information = lambda: LDAPInfo(phone="+3601234", email="abc@def.com", name=None)
         return plugin
 
@@ -59,20 +59,36 @@ def mocked_plugin(mocked_client):
 
 
 def test_cache_user_id(mocked_plugin):
-    plugin = mocked_plugin(user_doesnt_exist=False)
-    expected_cached_value = {"user_id": USED_ID, "is_valid": True}
+    plugin = mocked_plugin(USER_ID)
+    expected_cached_value = {"user_id": USER_ID, "is_valid": True}
     assert_cached_user_id(plugin, expected_cached_value)
 
 
 def test_cache_invalid_user_id_if_user_doesnt_exist(mocked_plugin):
-    plugin = mocked_plugin(user_doesnt_exist=True)
+    plugin = mocked_plugin(None)
     expected_cached_value = {"user_id": None, "is_valid": False}
     assert_cached_user_id(plugin, expected_cached_value)
 
 
 def assert_cached_user_id(plugin, expected_cached_value):
     plugin.authenticate(
-        cookie=dict(), session_cookie=dict(), gateway_username="wsmith", key_value_pairs=dict(otp="otp"),
+        cookie=dict(), session_cookie=dict(), gateway_username="wsmith", key_value_pairs=dict(otp="otp")
     )
     cached = plugin.cache.get(USER_ID_CACHE_KEY)
     assert cached == expected_cached_value
+
+
+def test_warn_about_non_numeric_mfa_identity(mocked_plugin, caplog):
+    plugin = mocked_plugin(USER_ID)
+    plugin.authenticate(
+        cookie=dict(), session_cookie=dict(), gateway_username="wsmith", key_value_pairs=dict(otp="otp")
+    )
+    assert "The MFA identity (user_id) does not look like a Starling ID which contains only digits!" in caplog.text
+
+
+def test_no_warning_for_numeric_mfa_identity(mocked_plugin, caplog):
+    plugin = mocked_plugin("12345678")
+    plugin.authenticate(
+        cookie=dict(), session_cookie=dict(), gateway_username="wsmith", key_value_pairs=dict(otp="otp")
+    )
+    assert "does not look like a Starling ID" not in caplog.text


### PR DESCRIPTION
It is a common error that users map gateway user to email address and
not the numeric Starling ID. Warn about this.

Modified test to easily inject different Straling ID.

References: jira PAM-11286
Signed-off-by: Gyorgy Krajcsovits <gyorgy.krajcsovits@oneidentity.com>